### PR TITLE
Add CSV import pipeline with mock parser

### DIFF
--- a/app/backend/parsers.py
+++ b/app/backend/parsers.py
@@ -1,0 +1,60 @@
+import csv
+import hashlib
+from datetime import datetime
+from typing import Iterable, Protocol, IO
+
+from .schemas import TransactionIn
+
+
+class BaseParser(Protocol):
+    name: str
+
+    def sniff(self, header: list[str]) -> bool:
+        ...
+
+    def parse(self, file_obj: IO[bytes]) -> Iterable[TransactionIn]:
+        ...
+
+
+class WorldlineMockParser:
+    name = "mock_worldline"
+
+    expected_fields = {
+        "selling_point",
+        "ept",
+        "amount_cents",
+        "currency",
+        "occurred_at",
+        "card_last4",
+    }
+
+    def sniff(self, header: list[str]) -> bool:
+        return set(header) >= self.expected_fields
+
+    def parse(self, file_obj: IO[bytes]) -> Iterable[TransactionIn]:
+        text = file_obj.read().decode("utf-8")
+        reader = csv.DictReader(text.splitlines())
+        for row in reader:
+            normalized = "|".join(
+                [
+                    row["selling_point"],
+                    row["ept"],
+                    row["amount_cents"],
+                    row["currency"],
+                    row["occurred_at"],
+                    row["card_last4"],
+                ]
+            )
+            source_row_hash = hashlib.sha256(normalized.encode()).hexdigest()
+            yield TransactionIn(
+                selling_point_name=row["selling_point"],
+                ept_label=row["ept"],
+                amount_cents=int(row["amount_cents"]),
+                currency=row["currency"],
+                occurred_at=datetime.fromisoformat(row["occurred_at"]),
+                card_last4=row["card_last4"],
+                source_row_hash=source_row_hash,
+            )
+
+
+PARSER_REGISTRY: dict[str, BaseParser] = {"mock_worldline": WorldlineMockParser()}

--- a/app/backend/samples/worldline_mock.csv
+++ b/app/backend/samples/worldline_mock.csv
@@ -1,0 +1,3 @@
+selling_point,ept,amount_cents,currency,occurred_at,card_last4
+Gate A,Terminal 1,1000,CHF,2024-01-01T10:00:00,1234
+Gate A,Terminal 1,2000,CHF,2024-01-01T11:00:00,5678

--- a/app/backend/schemas.py
+++ b/app/backend/schemas.py
@@ -78,6 +78,24 @@ class EPTRead(EPTBase):
         orm_mode = True
 
 
+# Transactions / Imports
+class TransactionIn(BaseModel):
+    selling_point_name: str
+    ept_label: Optional[str] = None
+    amount_cents: int
+    currency: str
+    occurred_at: datetime
+    card_last4: str
+    source_row_hash: str
+
+
+class ImportSummary(BaseModel):
+    processed: int
+    inserted: int
+    skipped_duplicates: int
+    errors: int
+
+
 # Summary schemas
 class EPTSummary(BaseModel):
     id: str

--- a/app/backend/tests/test_api.py
+++ b/app/backend/tests/test_api.py
@@ -9,6 +9,7 @@ from fastapi.testclient import TestClient
 
 from backend.main import app
 from backend.db import Base, engine
+from backend.parsers import PARSER_REGISTRY
 
 client = TestClient(app)
 
@@ -50,3 +51,54 @@ def test_summary_empty():
     data = r.json()
     assert data["event_id"] == event_id
     assert data["selling_points"] == []
+
+
+def test_mock_parser():
+    parser = PARSER_REGISTRY["mock_worldline"]
+    sample = Path(__file__).resolve().parents[1] / "samples" / "worldline_mock.csv"
+    with sample.open("rb") as f:
+        rows = list(parser.parse(f))
+    assert len(rows) == 2
+    assert rows[0].amount_cents == 1000
+
+
+def test_csv_import():
+    # Create event
+    payload = {
+        "name": "Import Event",
+        "start_at": datetime.utcnow().isoformat(),
+        "end_at": (datetime.utcnow() + timedelta(hours=1)).isoformat(),
+    }
+    r = client.post("/events/", json=payload)
+    event_id = r.json()["id"]
+
+    # Create selling point
+    sp_payload = {"name": "Gate A", "latitude": 0.0, "longitude": 0.0}
+    r = client.post(f"/events/{event_id}/selling-points", json=sp_payload)
+    sp_id = r.json()["id"]
+
+    # Create EPT
+    ept_payload = {"provider": "worldline", "label": "Terminal 1"}
+    r = client.post(f"/events/selling-points/{sp_id}/epts", json=ept_payload)
+    ept_id = r.json()["id"]
+
+    sample = Path(__file__).resolve().parents[1] / "samples" / "worldline_mock.csv"
+    with sample.open("rb") as f:
+        r = client.post(
+            f"/events/{event_id}/imports",
+            data={"parser": "mock_worldline"},
+            files={"file": ("worldline_mock.csv", f, "text/csv")},
+        )
+    assert r.status_code == 200
+    data = r.json()
+    assert data == {"processed": 2, "inserted": 2, "skipped_duplicates": 0, "errors": 0}
+
+    # Re-upload should skip duplicates
+    with sample.open("rb") as f:
+        r = client.post(
+            f"/events/{event_id}/imports",
+            data={"parser": "mock_worldline"},
+            files={"file": ("worldline_mock.csv", f, "text/csv")},
+        )
+    data = r.json()
+    assert data == {"processed": 2, "inserted": 0, "skipped_duplicates": 2, "errors": 0}


### PR DESCRIPTION
## Summary
- implement extensible CSV parsing system with a mock Worldline parser
- add `/events/{event_id}/imports` endpoint to ingest CSV transactions with idempotency
- include sample CSV and comprehensive tests for parser and import flow

## Testing
- `cd app/backend && pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68af0b30a3688322a56f5606f33bd68b