### PR TITLE
feat(frontend): add event list and summary pages

### DIFF
--- a/app/frontend/package-lock.json
+++ b/app/frontend/package-lock.json
@@ -8,8 +8,13 @@
       "name": "frontend",
       "version": "0.0.0",
       "dependencies": {
+        "@hookform/resolvers": "^5.2.1",
+        "@tanstack/react-query": "^5.85.5",
         "react": "^19.1.1",
-        "react-dom": "^19.1.1"
+        "react-dom": "^19.1.1",
+        "react-hook-form": "^7.62.0",
+        "react-router-dom": "^7.8.2",
+        "zod": "^4.1.3"
       },
       "devDependencies": {
         "@eslint/js": "^9.33.0",
@@ -935,6 +940,18 @@
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
+    "node_modules/@hookform/resolvers": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/@hookform/resolvers/-/resolvers-5.2.1.tgz",
+      "integrity": "sha512-u0+6X58gkjMcxur1wRWokA7XsiiBJ6aK17aPZxhkoYiK5J+HcTx0Vhu9ovXe6H+dVpO6cjrn2FkJTryXEMlryQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/utils": "^0.3.0"
+      },
+      "peerDependencies": {
+        "react-hook-form": "^7.55.0"
+      }
+    },
     "node_modules/@humanfs/core": {
       "version": "0.19.1",
       "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
@@ -1698,6 +1715,12 @@
         "win32"
       ]
     },
+    "node_modules/@standard-schema/utils": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
+      "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
+      "license": "MIT"
+    },
     "node_modules/@tailwindcss/cli": {
       "version": "4.1.12",
       "resolved": "https://registry.npmjs.org/@tailwindcss/cli/-/cli-4.1.12.tgz",
@@ -2001,6 +2024,32 @@
         "@tailwindcss/oxide": "4.1.12",
         "postcss": "^8.4.41",
         "tailwindcss": "4.1.12"
+      }
+    },
+    "node_modules/@tanstack/query-core": {
+      "version": "5.85.5",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.85.5.tgz",
+      "integrity": "sha512-KO0WTob4JEApv69iYp1eGvfMSUkgw//IpMnq+//cORBzXf0smyRwPLrUvEe5qtAEGjwZTXrjxg+oJNP/C00t6w==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/react-query": {
+      "version": "5.85.5",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.85.5.tgz",
+      "integrity": "sha512-/X4EFNcnPiSs8wM2v+b6DqS5mmGeuJQvxBglmDxl6ZQb5V26ouD2SJYAcC3VjbNwqhY2zjxVD15rDA5nGbMn3A==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-core": "5.85.5"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19"
       }
     },
     "node_modules/@types/babel__core": {
@@ -2630,6 +2679,15 @@
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/cookie": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.0.2.tgz",
+      "integrity": "sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -3983,6 +4041,22 @@
         "react": "^19.1.1"
       }
     },
+    "node_modules/react-hook-form": {
+      "version": "7.62.0",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.62.0.tgz",
+      "integrity": "sha512-7KWFejc98xqG/F4bAxpL41NB3o1nnvQO1RWZT3TqRZYL8RryQETGfEdVnJN2fy1crCiBLLjkRBVK05j24FxJGA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/react-hook-form"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17 || ^18 || ^19"
+      }
+    },
     "node_modules/react-refresh": {
       "version": "0.17.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.17.0.tgz",
@@ -3991,6 +4065,44 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-router": {
+      "version": "7.8.2",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.8.2.tgz",
+      "integrity": "sha512-7M2fR1JbIZ/jFWqelpvSZx+7vd7UlBTfdZqf6OSdF9g6+sfdqJDAWcak6ervbHph200ePlu+7G8LdoiC3ReyAQ==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "^1.0.1",
+        "set-cookie-parser": "^2.6.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "7.8.2",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.8.2.tgz",
+      "integrity": "sha512-Z4VM5mKDipal2jQ385H6UBhiiEDlnJPx6jyWsTYoZQdl5TrjxEV2a9yl3Fi60NBJxYzOTGTTHXPi0pdizvTwow==",
+      "license": "MIT",
+      "dependencies": {
+        "react-router": "7.8.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
       }
     },
     "node_modules/resolve-from": {
@@ -4093,6 +4205,12 @@
       "bin": {
         "semver": "bin/semver.js"
       }
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.1.tgz",
+      "integrity": "sha512-IOc8uWeOZgnb3ptbCURJWNjWUPcO3ZnTTdzsurqERrP6nPyv+paC55vJM0LpOlT2ne+Ix+9+CRG1MNLlyZ4GjQ==",
+      "license": "MIT"
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
@@ -4518,6 +4636,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.1.3.tgz",
+      "integrity": "sha512-1neef4bMce1hNTrxvHVKxWjKfGDn0oAli3Wy1Uwb7TRO1+wEwoZUZNP1NXIEESybOBiFnBOhI6a4m6tCLE8dog==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/app/frontend/package.json
+++ b/app/frontend/package.json
@@ -10,8 +10,13 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@hookform/resolvers": "^5.2.1",
+    "@tanstack/react-query": "^5.85.5",
     "react": "^19.1.1",
-    "react-dom": "^19.1.1"
+    "react-dom": "^19.1.1",
+    "react-hook-form": "^7.62.0",
+    "react-router-dom": "^7.8.2",
+    "zod": "^4.1.3"
   },
   "devDependencies": {
     "@eslint/js": "^9.33.0",

--- a/app/frontend/src/App.tsx
+++ b/app/frontend/src/App.tsx
@@ -1,20 +1,14 @@
-import { useEffect, useState } from "react";
+import { BrowserRouter, Routes, Route } from 'react-router-dom';
+import EventsList from './pages/EventsList';
+import EventDetail from './pages/EventDetail';
 
-function App() {
-  const [status, setStatus] = useState<string>("loading");
-
-  useEffect(() => {
-    fetch("http://localhost:8000/health")
-      .then((res) => res.json())
-      .then((data) => setStatus(data.status))
-      .catch(() => setStatus("error"));
-  }, []);
-
+export default function App() {
   return (
-    <div className="p-8">
-      <h1 className="text-2xl font-bold mb-4">Health status: {status}</h1>
-    </div>
+    <BrowserRouter>
+      <Routes>
+        <Route path="/" element={<EventsList />} />
+        <Route path="/events/:id" element={<EventDetail />} />
+      </Routes>
+    </BrowserRouter>
   );
 }
-
-export default App;

--- a/app/frontend/src/api.ts
+++ b/app/frontend/src/api.ts
@@ -1,0 +1,52 @@
+export interface Event {
+  id: string;
+  name: string;
+  start_at: string;
+  end_at: string;
+}
+
+export interface EPTSummary {
+  id: string;
+  label: string;
+  total_cents: number;
+}
+
+export interface SellingPointSummary {
+  id: string;
+  name: string;
+  total_cents: number;
+  epts: EPTSummary[];
+}
+
+export interface EventSummary {
+  event_id: string;
+  selling_points: SellingPointSummary[];
+}
+
+const API_URL = import.meta.env.VITE_API_URL ?? 'http://localhost:8000';
+
+export async function fetchEvents(): Promise<Event[]> {
+  const res = await fetch(`${API_URL}/events/`);
+  if (!res.ok) throw new Error('Failed to fetch events');
+  return res.json();
+}
+
+export async function createEvent(data: {
+  name: string;
+  start_at: string;
+  end_at: string;
+}): Promise<Event> {
+  const res = await fetch(`${API_URL}/events/`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(data),
+  });
+  if (!res.ok) throw new Error('Failed to create event');
+  return res.json();
+}
+
+export async function fetchEventSummary(id: string): Promise<EventSummary> {
+  const res = await fetch(`${API_URL}/events/${id}/summary`);
+  if (!res.ok) throw new Error('Failed to fetch summary');
+  return res.json();
+}

--- a/app/frontend/src/main.tsx
+++ b/app/frontend/src/main.tsx
@@ -1,10 +1,15 @@
-import { StrictMode } from 'react'
-import { createRoot } from 'react-dom/client'
-import './index.css'
-import App from './App.tsx'
+import { StrictMode } from 'react';
+import { createRoot } from 'react-dom/client';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import './index.css';
+import App from './App';
+
+const queryClient = new QueryClient();
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <App />
+    <QueryClientProvider client={queryClient}>
+      <App />
+    </QueryClientProvider>
   </StrictMode>,
-)
+);

--- a/app/frontend/src/pages/EventDetail.tsx
+++ b/app/frontend/src/pages/EventDetail.tsx
@@ -1,0 +1,43 @@
+import { useParams, Link } from 'react-router-dom';
+import { useQuery } from '@tanstack/react-query';
+import { fetchEventSummary, EventSummary } from '../api';
+
+export default function EventDetail() {
+  const { id } = useParams();
+  const { data: summary } = useQuery<EventSummary>({
+    queryKey: ['summary', id],
+    queryFn: () => fetchEventSummary(id as string),
+    enabled: !!id,
+  });
+
+  if (!summary) {
+    return <div className="p-8">Loading...</div>;
+  }
+
+  return (
+    <div className="p-8 space-y-4">
+      <Link to="/" className="text-blue-600 underline">
+        ← Back
+      </Link>
+      <h1 className="text-2xl font-bold">Event Summary</h1>
+      {summary.selling_points.length === 0 ? (
+        <p>No data.</p>
+      ) : (
+        summary.selling_points.map((sp) => (
+          <div key={sp.id} className="border p-2">
+            <h2 className="font-semibold">
+              {sp.name} - {(sp.total_cents / 100).toFixed(2)}
+            </h2>
+            <ul className="ml-4 list-disc">
+              {sp.epts.map((ept) => (
+                <li key={ept.id}>
+                  {ept.label}: {(ept.total_cents / 100).toFixed(2)}
+                </li>
+              ))}
+            </ul>
+          </div>
+        ))
+      )}
+    </div>
+  );
+}

--- a/app/frontend/src/pages/EventsList.tsx
+++ b/app/frontend/src/pages/EventsList.tsx
@@ -1,0 +1,70 @@
+import { Link } from 'react-router-dom';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { useForm } from 'react-hook-form';
+import { z } from 'zod';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { createEvent, fetchEvents, Event } from '../api';
+
+const schema = z.object({
+  name: z.string().min(1),
+  start_at: z.string(),
+  end_at: z.string(),
+});
+
+type FormData = z.infer<typeof schema>;
+
+export default function EventsList() {
+  const queryClient = useQueryClient();
+  const { data: events } = useQuery<Event[]>({
+    queryKey: ['events'],
+    queryFn: fetchEvents,
+  });
+
+  const { register, handleSubmit, reset } = useForm<FormData>({
+    resolver: zodResolver(schema),
+  });
+
+  const mutation = useMutation({
+    mutationFn: createEvent,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['events'] });
+      reset();
+    },
+  });
+
+  const onSubmit = (data: FormData) => mutation.mutate(data);
+
+  return (
+    <div className="p-8 space-y-4">
+      <h1 className="text-2xl font-bold">Events</h1>
+
+      <form onSubmit={handleSubmit(onSubmit)} className="flex gap-2">
+        <input {...register('name')} placeholder="Name" className="border p-1" />
+        <input {...register('start_at')} type="datetime-local" className="border p-1" />
+        <input {...register('end_at')} type="datetime-local" className="border p-1" />
+        <button type="submit" className="bg-blue-500 text-white px-2 py-1">Create</button>
+      </form>
+
+      <table className="min-w-full border">
+        <thead>
+          <tr className="bg-gray-100">
+            <th className="p-2 text-left">Name</th>
+            <th className="p-2">Start</th>
+            <th className="p-2">End</th>
+          </tr>
+        </thead>
+        <tbody>
+          {events?.map((ev) => (
+            <tr key={ev.id} className="border-t">
+              <td className="p-2 text-blue-600 underline">
+                <Link to={`/events/${ev.id}`}>{ev.name}</Link>
+              </td>
+              <td className="p-2">{new Date(ev.start_at).toLocaleString()}</td>
+              <td className="p-2">{new Date(ev.end_at).toLocaleString()}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Add event list page with creation form using React Hook Form and Zod
- Introduce event detail page that displays selling point and terminal totals
- Configure React Router and React Query for data fetching

## Testing
- `npm run lint`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68af0cdef388832294021c3d7c3ec5f8